### PR TITLE
Cron: Guard backup and notify with flock

### DIFF
--- a/backup/backup-cron
+++ b/backup/backup-cron
@@ -1,3 +1,3 @@
 # m h  dom mon dow   command
-0 3 * * * root . $HOME/.env.sh; python3 /scripts/backup.py -i -b -c >> /var/log/cron.log 2>&1
+0 3 * * * root . $HOME/.env.sh; /usr/bin/flock /tmp/auth.lock python3 /scripts/backup.py -i -b -c >> /var/log/cron.log 2>&1
 # An empty line is required at the end of this file for a valid cron file..

--- a/notify/notify-cron
+++ b/notify/notify-cron
@@ -1,4 +1,4 @@
 # m h  dom mon dow   command
-*/5 * * * * root . $HOME/.env.sh; python3 /scripts/notify_users.py >> /var/log/cron.log 2>&1
-0 * * * * root . $HOME/.env.sh; python3 /scripts/notify_permissions.py >> /var/log/cron.log 2>&1
+*/5 * * * * root . $HOME/.env.sh; /usr/bin/flock /tmp/auth.lock python3 /scripts/notify_users.py >> /var/log/cron.log 2>&1
+0 * * * * root . $HOME/.env.sh; /usr/bin/flock /tmp/auth.lock python3 /scripts/notify_permissions.py >> /var/log/cron.log 2>&1
 # An empty line is required at the end of this file for a valid cron file..


### PR DESCRIPTION
Use flock to avoid running both backup and notify cron job at the same time. Should fix empty mail issue when backup is running.